### PR TITLE
Prend en comptes toutes les aides au logement

### DIFF
--- a/openfisca_paris/paris.py
+++ b/openfisca_paris/paris.py
@@ -224,11 +224,11 @@ class paris_condition_taux_effort(Variable):
 
         taux_effort = legislation(period).paris.paris_logement.taux_effort
         loyer = famille.demandeur.menage('loyer', period)
-        apl = famille('apl', period)
+        aide_logement = famille('aide_logement', period)
 
         ressources_mensuelles = famille('paris_base_ressources_commun', period)
         charges_forfaitaire_logement = famille('aide_logement_charges', period)
-        calcul_taux_effort = (loyer + charges_forfaitaire_logement - apl) / ressources_mensuelles
+        calcul_taux_effort = (loyer + charges_forfaitaire_logement - aide_logement) / ressources_mensuelles
         condition_loyer = calcul_taux_effort >= taux_effort
         return condition_loyer
 

--- a/openfisca_paris/paris_condition_taux_effort.yaml
+++ b/openfisca_paris/paris_condition_taux_effort.yaml
@@ -1,0 +1,10 @@
+- name: "Taux d'effort trop faible à 26%"
+  period: 2017-07
+  input_variables:
+    loyer: 380
+    aide_logement: 309
+    paris_base_ressources_commun: 466
+  output_variables:
+    aide_logement_charges: 53.27
+    paris_condition_taux_effort: false
+    paris_logement: 0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'OpenFisca-Core >= 15, < 16',
-        'OpenFisca-France >= 18, < 19'
+        'OpenFisca-France >= 18, < 18.7'
     ],
     extras_require = {
         'test': 'nose'

--- a/tests/test_taux_effort.yaml
+++ b/tests/test_taux_effort.yaml
@@ -1,11 +1,8 @@
 name: Personne en situation de handicap taux d'effort < minimum
 description: La personne n'est pas éligible à l'aide au logement de la ville de Paris car son taux d'effort pour le financement de son loyer est inférieur au minimum.
 output_variables:
-  # paris_base_ressources_commun: ??
-  # aide_logement_charges: ??
-  # apl: ??
-  # paris_condition_taux_effort: false
-  # paris_logement_elig_pa_ph: false
+  paris_condition_taux_effort: false
+  paris_logement_elig_pa_ph: false
   paris_logement_pa_ph: 0
   paris_logement: 0
 absolute_error_margin: 0.1


### PR DESCRIPTION
Mise à jour de la condition de taux d'effort qui reposait uniquement sur
les APLs et non toutes les aides au logement.